### PR TITLE
Disk Install Fixes for PXE Mediums

### DIFF
--- a/crucible/install.py
+++ b/crucible/install.py
@@ -68,6 +68,7 @@ def install_to_disk(
                      'to use. Please choose an integer (0 < x).')
         sys.exit(1)
     directory = os.path.dirname(__file__)
+    click.echo('Installing OS to disk ... ')
     install_script = os.path.join(directory, 'scripts', 'install.sh')
     result = run_command(
         [

--- a/crucible/scripts/ifnames.sh
+++ b/crucible/scripts/ifnames.sh
@@ -45,13 +45,6 @@ highspeed_network_ids=(
 '15b3:101b'
 )
 
-blessed_names=(
-hsn
-mgmt
-lan
-)
-
-
 TEMP=$(mktemp -d)
 RULES='80-ifname.rules'
 

--- a/crucible/scripts/install.sh
+++ b/crucible/scripts/install.sh
@@ -61,7 +61,7 @@ METAL_SUBSYSTEMS='scsi|nvme'
 METAL_SUBSYSTEMS_IGNORE='usb'
 
 
-LOG=/var/log/$0.log
+LOG="/var/log/crucible/$(basename $0).log"
 >"${LOG}"
 
 boot_drive_scheme=LABEL

--- a/crucible/scripts/install.sh
+++ b/crucible/scripts/install.sh
@@ -445,20 +445,6 @@ function setup_bootloader {
 
     # Get the cloud-init datasource, if present.
     init_cmdline=$(cat /proc/cmdline)
-    found_ds=0
-    for cmd in $init_cmdline; do
-        if [[ "$cmd" =~ ^ds=.* ]]; then
-            ds="$cmd"
-        fi
-    done
-
-    # TODO: only append for installs from the ISO, PXE boots will already have this on the command line.
-    if [ -n "$ds" ]; then
-        # Append our existing ds command,(i.e. ds=nocloud-net;s=http://$url will get the ; escaped)
-        disk_cmdline+=( "${ds//;/\\;}" )
-    else
-        disk_cmdline+=( 'ds=nocloud\;s=/metal' )
-    fi
 
     # Make our grub.cfg file.
     cat << EOF > "$mpoint/boot/grub2/grub.cfg"

--- a/crucible/scripts/wipe.sh
+++ b/crucible/scripts/wipe.sh
@@ -113,7 +113,7 @@ if [ "${DRY_RUN}" -ne 0 ]; then
 fi
 
 mkdir -p /var/log/crucible/
-exec 2>"/var/log/crucible/$0.err"
+exec 2>"/var/log/crucible/$(basename $0).err"
 
 if [ -n "$root_disk" ]; then
     if [[ "$doomed_disks" =~ .*"/dev/${root_disk}".* ]]; then

--- a/crucible/scripts/wipe.sh
+++ b/crucible/scripts/wipe.sh
@@ -109,7 +109,7 @@ if [ "${DRY_RUN}" -ne 0 ]; then
             echo "Root is installed   : [$root_disk]"
         fi
     fi
-    exit 0
+    exit 2
 fi
 
 mkdir -p /var/log/crucible/

--- a/crucible/scripts/wipe.sh
+++ b/crucible/scripts/wipe.sh
@@ -115,9 +115,11 @@ fi
 mkdir -p /var/log/crucible/
 exec 2>"/var/log/crucible/$0.err"
 
-if [[ "$doomed_disks" =~ .*"/dev/${root_disk}".* ]]; then
-    echo >&2 "Root is installed on [$root_disk] which is targeted to be wiped! Aborting!"
-    exit 1
+if [ -n "$root_disk" ]; then
+    if [[ "$doomed_disks" =~ .*"/dev/${root_disk}".* ]]; then
+        echo >&2 "Root is installed on [$root_disk] which is targeted to be wiped! Aborting!"
+        exit 1
+    fi
 fi
 
 vgscan >&2 && vgs >&2

--- a/crucible/scripts/write-livecd.sh
+++ b/crucible/scripts/write-livecd.sh
@@ -250,9 +250,10 @@ temp_mount=$(mktemp -d)
 mount ${usb}3 $temp_mount
 LABEL=$(blkid -s LABEL -o value ${usb}1)
 USB_ISO_UUID=$(blkid -s UUID -o value /dev/disk/by-label/$LABEL)
-mkdir -v -m 0755 -p \
+mkdir -v -p \
     "${temp_mount}/LiveOS/overlay-${LABEL}-${USB_ISO_UUID}" \
-    "${temp_mount}//LiveOS/overlay-${LABEL}-${USB_ISO_UUID}/../ovlwork"
+    "${temp_mount}/LiveOS/overlay-${LABEL}-${USB_ISO_UUID}/../ovlwork"
+chmod -R 0755 "${temp_mount}/LiveOS/*"
 umount $temp_mount
 rmdir $temp_mount
 


### PR DESCRIPTION
## Major Changes

- Fixes bad variable handling causing `crucible storage wipe` to fail when PXE booted (Follow-up to #7)
- Fixes disk installations from a PXE booted medium where the squashFS file was missing causing the disk boot to fail.
- Disk installations from a PXE medium will now install root credentials, PXE contexts will have customer/user set credentials already and these (at least while the product is maturing) should be copied to disk for access following the reboot out of PXE

## Minor Changes

- Fixes log file locations for `install` and `storage wipe` commands, that previously were failing to log.
- Fixes return values from the BASH scripts, letting the Python application recognize and report a failure properly instead of reporting false successes.
- Removes cruft from earlier days of testing cloud-init on the hypervisor