### PR TITLE
NIC Configuration Updates and MGMT VM Automation

### DIFF
--- a/crucible.spec
+++ b/crucible.spec
@@ -28,6 +28,8 @@
 # https://github.com/openSUSE/python-rpm-macros#terminology
 %define pythons %(echo $PYTHON_BIN)
 
+%define conf_dir /etc/%{name}
+
 # python*-devel is not listed because we do not ship the ability to rebuild our PIP package.
 AutoReqProv: no
 BuildRequires: python-rpm-generators
@@ -73,8 +75,12 @@ sed -i 's:^#!.*$:#!%{install_dir}/bin/python:' %{buildroot}%{install_dir}/bin/%{
 # Add the PoC mock files
 cp -pr poc-mocks %{buildroot}%{install_dir}
 
-mkdir -p %{buildroot}/usr/bin/
-ln -snf %{install_dir}/bin/%{name} %{buildroot}/usr/bin/%{name}
+install -D -m 755 -d %{buildroot}%{_bindir}
+ln -snf %{install_dir}/scripts/lsnics.sh %{buildroot}%{_bindir}/lsnics
+ln -snf %{install_dir}/bin/%{name} %{buildroot}%{_bindir}/%{name}
+
+install -D -m 755 -d %{buildroot}%{conf_dir}
+install -m 644 %{name}/network/ifname.yml %{buildroot}%{conf_dir}/ifname.yml
 
 find %{buildroot}%{install_dir} | sed 's:'${RPM_BUILD_ROOT}'::' | tee -a INSTALLED_FILES
 cat INSTALLED_FILES | xargs -i sh -c 'test -f $RPM_BUILD_ROOT{} && echo {} || test -L $RPM_BUILD_ROOT{} && echo {} || echo %dir {}' | sort -u > FILES
@@ -83,6 +89,8 @@ cat INSTALLED_FILES | xargs -i sh -c 'test -f $RPM_BUILD_ROOT{} && echo {} || te
 
 %files -f FILES
 /usr/bin/%{name}
+/usr/bin/lsnics
+%config(noreplace) %{conf_dir}/ifname.yml
 %doc README.adoc
 %defattr(755,root,root)
 %license LICENSE

--- a/crucible/cli.py
+++ b/crucible/cli.py
@@ -30,6 +30,7 @@ import sys
 import click
 from click_option_group import optgroup
 from click_option_group import MutuallyExclusiveOptionGroup
+from crucible import vms
 
 from crucible.install import install_to_disk
 from crucible.network import config
@@ -321,3 +322,53 @@ def install(**kwargs) -> None:
     """
     LOG.info('Calling install with: %s', kwargs)
     install_to_disk(**kwargs)
+
+
+@crucible.group()
+def vm() -> None:
+    # pylint: disable=invalid-name
+    """
+    Functions for configuring VMs.
+
+    \f
+    """
+    LOG.info('Invoked vm group.')
+
+
+@vm.command()
+@click.option(
+    '--capacity',
+    default=100,
+    type=int,
+    is_flag=False,
+    metavar='<int>',
+    help="Capacity of the management VM disk in Gigabytes (default 100).",
+)
+@click.option(
+    '--interface',
+    default='lan0',
+    type=str,
+    is_flag=False,
+    help="Interface to use for the external network.",
+)
+@click.option(
+    '--ssh-key-path',
+    default='/root/.ssh/id_rsa.pub',
+    type=str,
+    is_flag=False,
+    help="Path to an SSH public key to add to the VM's root user.",
+)
+def start(**kwargs) -> None:
+    """
+    Starts the management VM.
+    :param kwargs:
+    """
+    vms.start(**kwargs)
+
+
+@vm.command()
+def reset() -> None:
+    """
+    Resets the VM, purges all assets.
+    """
+    vms.reset()

--- a/crucible/network/ifname.py
+++ b/crucible/network/ifname.py
@@ -363,7 +363,14 @@ def _ifname_meta() -> dict:
     """
     Opens the ifname.yml datafile.
     """
-    ifname_yml_path = os.path.join(os.path.dirname(__file__), 'ifname.yml')
+    default_yaml_path = '/etc/crucible/ifname'
+    if os.path.exists(f'{default_yaml_path}.yml'):
+        ifname_yml_path = os.path.join(f'{default_yaml_path}.yml')
+    elif os.path.exists(f'{default_yaml_path}.yaml'):
+        ifname_yml_path = os.path.join(f'{default_yaml_path}.yaml')
+    else:
+        ifname_yml_path = os.path.join(os.path.dirname(__file__), 'ifname.yml')
+    LOG.info('Using NIC database file: %s',ifname_yml_path)
     with open(ifname_yml_path, 'r', encoding='utf-8') as ifname_yml:
         return safe_load(ifname_yml.read())
 

--- a/crucible/scripts/install.sh
+++ b/crucible/scripts/install.sh
@@ -284,6 +284,7 @@ function partition_os {
 
     # metadata=0.9 for boot files.
     mdadm_raid_devices="--raid-devices=$metal_disks"
+    [ "$metal_disks" -eq 1 ] && mdadm_raid_devices="$mdadm_raid_devices --force"
     mdadm --create /dev/md/BOOT --run --verbose --assume-clean --metadata=0.9 --level="$metal_md_level" "$mdadm_raid_devices" "${boot_raid_parts[@]}" || metal_die -b "Failed to make filesystem on /dev/md/BOOT"
     mdadm --create /dev/md/SQFS --run --verbose --assume-clean --metadata=1.2 --level="$metal_md_level" "$mdadm_raid_devices" "${sqfs_raid_parts[@]}" || metal_die -b "Failed to make filesystem on /dev/md/SQFS"
     mdadm --create /dev/md/ROOT --assume-clean --run --verbose --metadata=1.2 --level="$metal_md_level" "$mdadm_raid_devices" "${oval_raid_parts[@]}" || metal_die -b "Failed to make filesystem on /dev/md/ROOT"

--- a/crucible/scripts/lsnics.sh
+++ b/crucible/scripts/lsnics.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+set -e
+
+function usage() {
+cat << 'EOF'
+Prints PCI Vendor and Device IDs for network devices.
+EOF
+}
+
+while getopts "hCPp:" o; do
+    case "${o}" in
+        h)
+            usage
+            exit 0
+            ;;
+        *)
+            :
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+mapfile -t nics < <(ls -1d /sys/bus/pci/drivers/*/*/net/*)
+
+if [ "${#nics[@]}" -eq 0 ]; then
+    echo >&2 'No NICs detected in /sys/bus/pci/drivers/'
+    exit 1
+fi
+
+printf '% -6s % -4s % -4s \n' 'Name' 'VID' 'DID'
+for nic in "${nics[@]}"; do
+    DID="$(awk -F: '/PCI_ID/{gsub("PCI_ID=","");print $NF}' "$(dirname "$(dirname "${nics[0]}")")/uevent")"
+    VID="$(awk -F: '/PCI_ID/{gsub("PCI_ID=","");print $1}' "$(dirname "$(dirname "${nics[0]}")")/uevent")"
+    printf '% -6s % -4s % -4s \n' "$(basename "$nic")" "${VID}" "${DID}"
+done

--- a/crucible/scripts/management-vm.sh
+++ b/crucible/scripts/management-vm.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+set -euo pipefail
+
+BOOTSTRAP=/srv/cray/bootstrap
+CAPACITY=100
+MGMTCLOUD=/vms/cloud-init/management-vm
+INTERFACE=lan0
+SSH_KEY=/root/.ssh/id_rsa.pub
+RESET=0
+error=0
+required_programs=( "yq" "xorriso" "virsh" )
+for required_program in "${required_programs[@]}"; do
+    if ! command -v  >/dev/null 2>&1 ; then
+        echo >&2 "$required_program is required but was not found in PATH."
+        error=1
+    fi
+done
+if [ "$error" -ne 0 ]; then
+    exit 1
+fi
+
+function usage {
+    cat << EOF
+-c      CAPACITY of the management VM storage (interpreted in Gigabytes), defaults to 100.
+-r      Resets the management VM. Destroys all volumes, pools, and the management virtual machine. Resets the cloud-init ISO.
+-s      SSH_KEY path to install into the management VM's root user (default: /root/.ssh/id_rsa.pub)
+-i      INTERFACE to use for the Management external network (default: lan0).
+EOF
+exit 0
+}
+
+while getopts ":rc:s:i:" o; do
+    case "${o}" in
+        c)
+            CAPACITY="${OPTARG}"
+            ;;
+        r)
+            RESET=1
+            ;;
+        i)
+            INTERFACE="${OPTARG}"
+            ;;
+        s)
+            SSH_KEY="${OPTARG}"
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+if [ "$RESET" -eq 1 ]; then
+    virsh destroy management-vm || echo 'Already destroyed ... '
+    virsh vol-delete --pool management-pool management-vm.qcow2 || echo 'Volume already deleted ... '
+    virsh pool-destroy management-pool || echo 'Pool already destroyed ... '
+    virsh pool-undefine management-pool || echo 'Pool already undefined ... '
+    virsh net-destroy isolated || echo 'Isolated network already destroyed ... '
+    virsh net-undefine isolated || echo 'Isolated network already undefined ... '
+    yq -i eval '(.users.[] | select(.name = "admin") | .ssh_authorized_keys) += ""' "${MGMTCLOUD}/user-data"
+    yq -i -o xml -p xml eval '.domain.devices.interface |= [
+    {"source": {"+network": "isolated"}, "model": {"+type": "virtio"}}
+    ]' "${BOOTSTRAP}/domain.xml"
+    rm -f "${MGMTCLOUD}/cloud-init.iso"
+    echo "Management VM was purged."
+    exit 0
+fi
+
+mkdir -p "${MGMTCLOUD}"
+cp -p "$BOOTSTRAP/meta-data" "${BOOTSTRAP}/user-data" ${MGMTCLOUD}
+
+yq -i eval '(.users.[] | select(.name = "admin") | .ssh_authorized_keys) += "'"$(cat "$SSH_KEY")"'"' "${MGMTCLOUD}/user-data"
+xorriso -as genisoimage \
+    -output "${MGMTCLOUD}/cloud-init.iso" \
+    -volid CIDATA -joliet -rock -f \
+    "${MGMTCLOUD}/user-data" \
+    "${MGMTCLOUD}/meta-data"
+
+virsh pool-define-as management-pool dir --target /var/lib/libvirt/management-pool
+virsh pool-build management-pool
+virsh pool-start management-pool
+virsh pool-autostart management-pool
+
+virsh vol-create-as --pool management-pool --name management-vm.qcow2 --capacity "${CAPACITY}G" --format qcow2
+virsh vol-upload --pool management-pool management-vm.qcow2 /vms/images/management-vm/*
+
+virsh net-define "${BOOTSTRAP}/isolated.xml"
+
+yq -i -o xml -p xml eval '.domain.devices.interface |= [
+{"source": {"+network": "isolated"}, "model": {"+type": "virtio"}},
+{"+type": "direct", "source": {"+dev": "bond0", "+mode": "bridge"}, "model": {"+type": "virtio"}},
+{"+type": "direct", "source": {"+dev": "'"$INTERFACE"'", "+mode": "bridge"}, "model": {"+type": "virtio"}}
+]' "${BOOTSTRAP}/domain.xml"
+
+virsh create "${BOOTSTRAP}/domain.xml"
+
+cat << EOF
+Management VM created ... observe its launch with:
+
+    virsh console management-vm
+EOF

--- a/crucible/tests/test_cli.py
+++ b/crucible/tests/test_cli.py
@@ -165,14 +165,45 @@ class TestCLI:
     def test_install_stripe(self, mock_run) -> None:
         """
         Tests that the ``install`` command does not fail if a stripe is given.
-        :param _:
-        :return:
+        :param mock_run:
         """
         result = self.runner.invoke(
             crucible,
             [
                 'install',
                 '--raid-level=stripe'
+            ],
+        )
+        assert result.exit_code == 0
+        assert mock_run.called
+
+    @mock.patch('crucible.vms.run_command', spec=True)
+    def test_vm_start(self, mock_run) -> None:
+        """
+        Tests that the ``vm`` command does not fail when is given.
+        :param mock_run:
+        """
+        result = self.runner.invoke(
+            crucible,
+            [
+                'vm',
+                'start',
+            ],
+        )
+        assert result.exit_code == 0
+        assert mock_run.called
+
+    @mock.patch('crucible.vms.run_command', spec=True)
+    def test_vm_reset(self, mock_run) -> None:
+        """
+        Tests that the ``vm`` command does not fail when is given.
+        :param mock_run:
+        """
+        result = self.runner.invoke(
+            crucible,
+            [
+                'vm',
+                'reset',
             ],
         )
         assert result.exit_code == 0

--- a/crucible/tests/test_os.py
+++ b/crucible/tests/test_os.py
@@ -22,9 +22,13 @@
 #  OTHER DEALINGS IN THE SOFTWARE.
 #
 """
-Tests for the ``cmd`` module.
+Tests for the ``os`` module.
 """
 from os import getcwd
+from subprocess import Popen
+
+import pytest
+import mock
 
 from crucible.os import run_command
 from crucible.os import chdir
@@ -32,8 +36,10 @@ from crucible.os import chdir
 
 class TestCLI:
     """
-    Test class for the ``cli`` module.
+    Test class for the ``os`` module.
     """
+
+    init = 0.0
 
     def test_run_command(self) -> None:
         """
@@ -49,14 +55,58 @@ class TestCLI:
         command_result = run_command(command)
         for result in [no_shell_result, shell_result, bad_result,
                        command_result]:
-            assert result.duration > 0.0
+            assert result.duration > self.init
             assert isinstance(result.return_code, int)
             assert result.stdout or result.stderr
+
+    def test_run_command_decode(self) -> None:
+        """
+        Assert that a ``_CLI`` object successfully decodes its ``stdout`` and
+        ``stderr``.
+        """
+        command = ['ls', '-l']
+        shell_command = 'ls -l'
+        bad_command = 'foo!!!'
+        no_shell_result = run_command(shell_command)
+        shell_result = run_command(
+            shell_command,
+            in_shell=True,
+            charset='utf-8'
+        )
+        bad_result = run_command(bad_command)
+        command_result = run_command(command)
+        for result in [no_shell_result, shell_result, bad_result,
+                       command_result]:
+            assert result.duration > self.init
+            assert isinstance(result.return_code, int)
+            assert result.stdout or result.stderr
+
+    def test_run_command_decode_unicode_error(self) -> None:
+        """
+        Assert that ``UnicodeDecodeErrors`` are caught by the ``run_command``
+        and a non-zero return code is received.
+        """
+        # Test using a CP1252 (windows ostensibly) character "œ"
+        byte_string = b'\x9c'
+        with mock.patch.object(
+                Popen,
+                'communicate',
+                return_value=(byte_string, byte_string)
+        ):
+            result = run_command(['ls', '-l'])
+            assert result.duration > self.init
+            assert isinstance(result.return_code, int)
+            assert result.stdout or result.stderr
+            assert isinstance(result.stdout, bytes)
+            assert isinstance(result.stderr, bytes)
+            with pytest.raises(UnicodeDecodeError):
+                run_command(['ls', '-l'], charset='utf-8')
 
     def test_chdir(self) -> None:
         """
         Assert that our context manager will change directories and
         change back to our original directory.
+
         """
         original = getcwd()
         with chdir('/'):

--- a/crucible/vms.py
+++ b/crucible/vms.py
@@ -1,0 +1,74 @@
+#
+#  MIT License
+#
+#  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+#  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+#  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#  OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Module for launching VMs.
+"""
+import os
+
+import click
+
+from crucible.os import run_command
+from crucible.logger import Logger
+
+
+LOG = Logger(__name__)
+directory = os.path.dirname(__file__)
+vm_script = os.path.join(directory, '..', 'scripts', 'management-vm.sh')
+
+
+def start(capacity: int, interface: str, ssh_key_path: str) -> None:
+    """
+    Starts the management VM.
+
+    :param capacity: Capacity (in Gigabytes) for the management VM
+                     storage (default 100).
+    :param interface: The interface for external networking (default lan0)
+    :param ssh_key_path: The path to the SSH key for the VM's root user
+                         (default: /root/.ssh/id_rsa.pub)
+    """
+
+    args = [vm_script]
+    if capacity:
+        args.extend(['-c', capacity])
+    if interface:
+        args.extend(['-i', interface])
+    if ssh_key_path:
+        args.extend(['-s', ssh_key_path])
+    click.echo('Starting management VM ... ')
+    result = run_command(args, in_shell=True)
+    if result.return_code != 0:
+        LOG.critical('Failed to start the management VM! Check logs.')
+    click.echo('Management VM started.')
+
+
+def reset() -> None:
+    """
+    Resets, purges the management VM.
+    """
+    args = [vm_script, '-r']
+    click.echo('Purging/resetting management VM ... ')
+    result = run_command(args, in_shell=True)
+    if result.return_code != 0:
+        LOG.critical('Failed cleanup the management VM! Check logs.')
+    click.echo('Management VM was purged.')

--- a/docs/modules/ROOT/pages/nic-configuration.adoc
+++ b/docs/modules/ROOT/pages/nic-configuration.adoc
@@ -27,31 +27,43 @@ By obtaining the PCI Vendor and Device ID, we can provide customization for clas
 * `lan`: external/site-connection
 
 The information belongs to the first 4 bytes of the PCI header, and admin can obtain it using `lspci` or `ethtool`.
-The snippet below will dump a formatted list of all detected Ethernet devices.
 
+If `crucible` is installed on the system, a helper script will be available in `/usr/bin`.
 [source,bash]
 ----
-alias lid='for file in $(ls -1d /sys/bus/pci/drivers/*/0000\:*/net/*); do printf "% -6s %s\n" "$(basename $file)" $(grep PCI_ID "$(dirname $(dirname $file))/uevent" | cut -f 2 -d '='); done'
+/usr/bin/lsnics
 ----
 
-The value on the left hand side of the value is the Vendor ID, and the right hand side is the Device ID.
-
+.Example
 [source,bash]
 ----
-host:~ # lid
-em1    8086:37D2
-em2    8086:37D2
-p801p1 15B3:1013
-p801p2 15B3:1013
+host:~ # lsnics
+Name   VID  DID
+em1    8086 37D2
+em2    8086 37D2
+p801p1 8086 37D2
+p801p2 8086 37D2
 ----
 
-=== Customizing
+=== Customizing `ifname.yml`
 
-At this time, the proof-of-concept version of Crucible does allow customization of which devices are named which NICs.
+To change which network interfaces are used for which purpose, or to add new ones, follow the directions below.
 
-To do so, edit the `/usr/lib/crucible/lib/python3.10/site-packages/crucible/network/ifname.yml` where Crucible is installed by populating the various categories with the requested information.
+. Edit the `/etc/crucible/ifname.yml` where Crucible is installed by populating the various categories with the requested information.
++
+[source,bash]
+----
+vim /etc/crucible/ifname.yml
+----
 
-==== Device and Vendor ID Quick Reference
+. Re-generate `udev` rules, overwriting the old ones if present.
++
+[source,bash]
+----
+crucible network udev --overwrite
+----
+
+=== Device and Vendor ID Quick Reference
 
 Below is a table of commonly used devices for Fawkes system, this table will continue to expand as Fawkes becomes more prevalent on a larger variety of hardware.
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,3 +1,4 @@
+#
 #  MIT License
 #
 #  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
@@ -20,28 +21,6 @@
 #  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 #  OTHER DEALINGS IN THE SOFTWARE.
 
-#
-# MIT License
-#
-#
-# Permission is hereby granted, free of charge, to any person obtaining a
-# copy of this software and associated documentation files (the "Software"),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-# OTHER DEALINGS IN THE SOFTWARE.
-#
 from pathlib import Path
 import sys
 


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

#### Issue Type

<!--- Delete un-needed bullets; choose one or more.  -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Adds the ability to parse an `/etc/crucible/ifname.yml` file, which is much easier to edit and refer to than the baked in default file.

Adds a new `lsnics` command (script) to print off existing NICs. This replaces the BASH alias in the `nic-configuration.adoc` file.

Updates the `install.sh` script to accept single-disk RAID arrays.

Removes duplicate license from `noxfile.py`.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required).
- [ ] I have added unit tests for my code.
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
