### PR TITLE
`yq` uses new attribute prefixes

### DIFF
--- a/crucible/scripts/management-vm.sh
+++ b/crucible/scripts/management-vm.sh
@@ -81,8 +81,8 @@ if [ "$RESET" -eq 1 ]; then
     virsh net-destroy isolated || echo 'Isolated network already destroyed ... '
     virsh net-undefine isolated || echo 'Isolated network already undefined ... '
     yq -i eval '(.users.[] | select(.name = "admin") | .ssh_authorized_keys) += ""' "${MGMTCLOUD}/user-data"
-    yq -i -o xml -p xml eval '.domain.devices.interface |= [
-    {"source": {"+network": "isolated"}, "model": {"+type": "virtio"}}
+    yq --xml-attribute-prefix='+@' -i -o xml -p xml eval '.domain.devices.interface |= [
+    {"source": {"+@network": "isolated"}, "model": {"+@type": "virtio"}}
     ]' "${BOOTSTRAP}/domain.xml"
     rm -f "${MGMTCLOUD}/cloud-init.iso"
     echo "Management VM was purged."
@@ -109,10 +109,10 @@ virsh vol-upload --pool management-pool management-vm.qcow2 /vms/images/manageme
 
 virsh net-define "${BOOTSTRAP}/isolated.xml"
 
-yq -i -o xml -p xml eval '.domain.devices.interface |= [
-{"source": {"+network": "isolated"}, "model": {"+type": "virtio"}},
-{"+type": "direct", "source": {"+dev": "bond0", "+mode": "bridge"}, "model": {"+type": "virtio"}},
-{"+type": "direct", "source": {"+dev": "'"$INTERFACE"'", "+mode": "bridge"}, "model": {"+type": "virtio"}}
+yq --xml-attribute-prefix='+@' -i -o xml -p xml eval '.domain.devices.interface |= [
+{"source": {"+@network": "isolated"}, "model": {"+@type": "virtio"}},
+{"+@type": "direct", "source": {"+@dev": "bond0", "+@mode": "bridge"}, "model": {"+@type": "virtio"}},
+{"+@type": "direct", "source": {"+@dev": "'"$INTERFACE"'", "+@mode": "bridge"}, "model": {"+@type": "virtio"}}
 ]' "${BOOTSTRAP}/domain.xml"
 
 virsh create "${BOOTSTRAP}/domain.xml"

--- a/crucible/scripts/management-vm.sh
+++ b/crucible/scripts/management-vm.sh
@@ -112,7 +112,7 @@ virsh net-start isolated || echo 'Already started'
 virsh net-autostart isolated || echo 'Already auto-started'
 
 yq --xml-attribute-prefix='+@' -i -o xml -p xml eval '.domain.devices.interface |= [
-{"source": {"+@network": "isolated"}, "model": {"+@type": "virtio"}},
+{"+@type": "network", "source": {"+@network": "isolated"}, "model": {"+@type": "virtio"}},
 {"+@type": "direct", "source": {"+@dev": "bond0", "+@mode": "bridge"}, "model": {"+@type": "virtio"}},
 {"+@type": "direct", "source": {"+@dev": "'"$INTERFACE"'", "+@mode": "bridge"}, "model": {"+@type": "virtio"}}
 ]' "${BOOTSTRAP}/domain.xml"

--- a/crucible/scripts/management-vm.sh
+++ b/crucible/scripts/management-vm.sh
@@ -108,6 +108,8 @@ virsh vol-create-as --pool management-pool --name management-vm.qcow2 --capacity
 virsh vol-upload --pool management-pool management-vm.qcow2 /vms/images/management-vm/*
 
 virsh net-define "${BOOTSTRAP}/isolated.xml"
+virsh net-start isolated || echo 'Already started'
+virsh net-autostart isolated || echo 'Already auto-started'
 
 yq --xml-attribute-prefix='+@' -i -o xml -p xml eval '.domain.devices.interface |= [
 {"source": {"+@network": "isolated"}, "model": {"+@type": "virtio"}},


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

#### Issue Type

<!--- Delete un-needed bullets; choose one or more.  -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
`yq` no longer uses `+` for denoting an attribute, instead it now uses `+@`.

This updates the `yq` calls to leverage the new attribute, and specifies `--xml-attribute-prefix` to prevent upstream from changing it underneath us again.


Before:
```bash
yq -o xml -p xml^Cval '.domain.devices.interface |= [
{"source": {"+network": "isolated"}, "model": {"+type": "virtio"}},
{"+type": "direct", "source": {"+dev": "bond0", "+mode": "bridge"}, "model": {"+type": "virtio"}},
{"+type": "direct", "source": {"+dev": "'"$INTERFACE"'", "+mode": "bridge"}, "model": {"+type": "virtio"}}
]' domain.xml
```
```xml
<domain type="kvm">
  <name>management-vm</name>
  <memory unit="MiB">4096</memory>
  <vcpu>4</vcpu>
  <os>
    <type arch="x86_64">hvm</type>
    <boot dev="hd"></boot>
  </os>
  <features>
    <acpi></acpi>
    <apic></apic>
    <pae></pae>
  </features>
  <cpu mode="custom" match="exact" check="full">
    <model fallback="forbid">qemu64</model>
    <feature policy="require" name="x2apic"></feature>
    <feature policy="require" name="hypervisor"></feature>
    <feature policy="require" name="lahf_lm"></feature>
    <feature policy="disable" name="svm"></feature>
  </cpu>
  <clock offset="utc"></clock>
  <on_poweroff>destroy</on_poweroff>
  <on_reboot>restart</on_reboot>
  <on_crash>restart</on_crash>
  <memoryBacking>
    <source type="memfd"></source>
    <access mode="shared"></access>
  </memoryBacking>
  <devices>
    <emulator>/usr/bin/qemu-system-x86_64</emulator>
    <console type="pty" tty="/dev/pts/0">
      <source path="/dev/pts/0"></source>
      <target port="0"></target>
    </console>
    <disk type="volume" device="disk">
      <driver name="qemu" type="qcow2"></driver>
      <source pool="management-pool" volume="management-vm.qcow2"></source>
      <backingStore></backingStore>
      <target dev="vda" bus="virtio"></target>
    </disk>
    <disk type="file" device="cdrom">
      <driver name="qemu" type="raw"></driver>
      <source file="/vms/cloud-init/management-vm/cloud-init.iso"></source>
      <target dev="hda" bus="ide"></target>
    </disk>
    <channel type="unix">
      <source mode="bind"></source>
      <target type="virtio" name="org.qemu.guest_agent.0"></target>
    </channel><!-- Start off with the default, isolated network. -->
    <interface>
      <source>
        <+network>isolated</+network>
      </source>
      <model>
        <+type>virtio</+type>
      </model>
    </interface>
    <interface>
      <+type>direct</+type>
      <source>
        <+dev>bond0</+dev>
        <+mode>bridge</+mode>
      </source>
      <model>
        <+type>virtio</+type>
      </model>
    </interface>
    <interface>
      <+type>direct</+type>
      <source>
        <+dev>lan0</+dev>
        <+mode>bridge</+mode>
      </source>
      <model>
        <+type>virtio</+type>
      </model>
    </interface>
  </devices>
</domain>
```

After, note that the attributes are properly defined in each XML element:
```bash
yq  --xml-attribute-prefix='+@' -o xml -p xml eval '.domain.devices.interface |= [
{"source": {"+@network": "isolated"}, "model": {"+@type": "virtio"}},
{"+@type": "direct", "source": {"+@dev": "bond0", "+@mode": "bridge"}, "model": {"+@type": "virtio"}},
{"+@type": "direct", "source": {"+@dev": "'"$INTERFACE"'", "+@mode": "bridge"}, "model": {"+@type": "virtio"}}
]' domain.xml
```
```xml
<domain type="kvm">
  <name>management-vm</name>
  <memory unit="MiB">4096</memory>
  <vcpu>4</vcpu>
  <os>
    <type arch="x86_64">hvm</type>
    <boot dev="hd"></boot>
  </os>
  <features>
    <acpi></acpi>
    <apic></apic>
    <pae></pae>
  </features>
  <cpu mode="custom" match="exact" check="full">
    <model fallback="forbid">qemu64</model>
    <feature policy="require" name="x2apic"></feature>
    <feature policy="require" name="hypervisor"></feature>
    <feature policy="require" name="lahf_lm"></feature>
    <feature policy="disable" name="svm"></feature>
  </cpu>
  <clock offset="utc"></clock>
  <on_poweroff>destroy</on_poweroff>
  <on_reboot>restart</on_reboot>
  <on_crash>restart</on_crash>
  <memoryBacking>
    <source type="memfd"></source>
    <access mode="shared"></access>
  </memoryBacking>
  <devices>
    <emulator>/usr/bin/qemu-system-x86_64</emulator>
    <console type="pty" tty="/dev/pts/0">
      <source path="/dev/pts/0"></source>
      <target port="0"></target>
    </console>
    <disk type="volume" device="disk">
      <driver name="qemu" type="qcow2"></driver>
      <source pool="management-pool" volume="management-vm.qcow2"></source>
      <backingStore></backingStore>
      <target dev="vda" bus="virtio"></target>
    </disk>
    <disk type="file" device="cdrom">
      <driver name="qemu" type="raw"></driver>
      <source file="/vms/cloud-init/management-vm/cloud-init.iso"></source>
      <target dev="hda" bus="ide"></target>
    </disk>
    <channel type="unix">
      <source mode="bind"></source>
      <target type="virtio" name="org.qemu.guest_agent.0"></target>
    </channel><!-- Start off with the default, isolated network. -->
    <interface>
      <source network="isolated"></source>
      <model type="virtio"></model>
    </interface>
    <interface type="direct">
      <source dev="bond0" mode="bridge"></source>
      <model type="virtio"></model>
    </interface>
    <interface type="direct">
      <source dev="lan0" mode="bridge"></source>
      <model type="virtio"></model>
    </interface>
  </devices>
</domain>
```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required).
- [ ] I have added unit tests for my code.
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
