### PR TITLE
Iso and nm updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ env/
 venv/
 ENV/
 env.bak/
+.nox/
 venv.bak/
 
 # Docs

--- a/crucible/cli.py
+++ b/crucible/cli.py
@@ -167,6 +167,13 @@ def udev(**kwargs) -> None:
     default=False,
     help='Denotes whether this should be the default route for the system.'
 )
+@click.option(
+    '--dns',
+    type=str,
+    default='',
+    help='Comma delimited list of one or more IP addresses for DNS'
+         '(only used on NetworkManager systems).'
+)
 def interface(**kwargs) -> None:
     # pylint: disable=invalid-name
     """
@@ -288,26 +295,32 @@ def wipe() -> None:
 
 @crucible.command()
 @click.option(
+    '-d',
     '--num-disks',
     default=2,
     type=int,
     is_flag=False,
     metavar='<int>',
-    help='Number of disks to use in the OS disk array (default: 2).', )
+    help='Number of disks to use in the OS disk array (default: 2).',
+)
 @click.option(
-    '--sqfs-storage-size',
-    default=25,
-    type=int,
-    is_flag=False,
-    metavar='<size GiB>',
-    help='Size of the squashFS storage partition (default: 25GiB).', )
-@click.option(
+    '-l',
     '--raid-level',
     default='mirror',
     type=str,
     is_flag=False,
     metavar='<mirror|stripe>',
-    help='Level of redundancy (default: mirror).', )
+    help='Level of redundancy (default: mirror).',
+)
+@click.option(
+    '-s',
+    '--ssh-key-path',
+    default='/root/.ssh/',
+    type=str,
+    is_flag=False,
+    help="Path to an SSH public key, or a directory of keys to install into "
+         "the management VM",
+)
 def install(**kwargs) -> None:
     """
     Install a running LIVE image to disk.
@@ -337,6 +350,7 @@ def vm() -> None:
 
 @vm.command()
 @click.option(
+    '-c',
     '--capacity',
     default=100,
     type=int,
@@ -345,6 +359,7 @@ def vm() -> None:
     help="Capacity of the management VM disk in Gigabytes (default 100).",
 )
 @click.option(
+    '-i',
     '--interface',
     default='lan0',
     type=str,
@@ -352,11 +367,13 @@ def vm() -> None:
     help="Interface to use for the external network.",
 )
 @click.option(
+    '-s',
     '--ssh-key-path',
-    default='/root/.ssh/id_rsa.pub',
+    default='/root/.ssh/',
     type=str,
     is_flag=False,
-    help="Path to an SSH public key to add to the VM's root user.",
+    help="Path to an SSH public key, or a directory of keys to install into "
+         "the management VM",
 )
 def start(**kwargs) -> None:
     """

--- a/crucible/install.py
+++ b/crucible/install.py
@@ -36,27 +36,21 @@ LOG = Logger(__name__)
 
 def install_to_disk(
         num_disks: int,
-        sqfs_storage_size: int,
         raid_level: str,
+        ssh_key_path: str,
 ) -> None:
     """
     Installs the running image to disk.
 
     :param num_disks: Number of disks to use for the OS array.
-    :param sqfs_storage_size: Size of squashFS storage.
     :param raid_level: Stripe or Mirror
+    :param ssh_key_path: Path to an SSH key, or a directory of keys to install.
     """
     if raid_level not in ['stripe', 'mirror']:
         LOG.critical('Chosen RAID level was [%s] but '
                      'only type "mirror" and "stripe" are supported.',
                      raid_level)
         sys.exit(1)
-    if sqfs_storage_size < 2:
-        LOG.critical('SquashFS was set to less than the minimum of 2 GiB!')
-        sys.exit(1)
-    elif sqfs_storage_size < 5:
-        LOG.warning('SquashFS storage is set to less than 5 GiB! '
-                    'Mileage may vary.')
     if num_disks < 2 and raid_level == 'stripe':
         LOG.critical('Number of disks was set to [< 2] but RAID level "stripe"'
                      ' was chosen, this can not be done. Please choose '
@@ -74,8 +68,8 @@ def install_to_disk(
         [
             install_script,
             '-d', num_disks,
-            '-s', sqfs_storage_size,
             '-l', raid_level,
+            '-s', ssh_key_path,
         ],
     )
     if result.return_code != 0:

--- a/crucible/network/ifname.py
+++ b/crucible/network/ifname.py
@@ -188,6 +188,7 @@ def map_nics() -> list[NIC]:
     for nic_file in nic_files:
         nic = os.path.basename(nic_file)
         mac_cmd = run_command(['ethtool', '-P', nic], silence=True)
+        mac_cmd.decode('utf-8')
         mac = mac_cmd.stdout.rsplit(' ', maxsplit=1)[-1]
 
         pci_id = ''
@@ -230,6 +231,7 @@ def _rename(nics: list[NIC]) -> None:
         LOG.info('Renaming %s to %s', nic.old_name, nic.name)
         was_up = False
         current_state = run_command(['ip', 'link', 'show', nic.old_name])
+        current_state.decode('utf-8')
         if current_state.return_code == 0:
             if 'UP' in current_state.stdout:
                 LOG.info(

--- a/crucible/network/manager.py
+++ b/crucible/network/manager.py
@@ -163,7 +163,7 @@ class Interface(IPAddr):
         self._vlan_id = 0
 
 
-class NetworkManager:
+class SystemNetwork:
 
     """
     Base class for a network manager object.
@@ -253,7 +253,7 @@ class NetworkManager:
         Updates the system's static DNS list.
         """
 
-    def write_config(self, config: str, *args) -> None:
+    def write_config(self) -> None:
         """
         Writes a configuration to a file.
         """

--- a/crucible/network/networkmanager.py
+++ b/crucible/network/networkmanager.py
@@ -1,0 +1,110 @@
+#
+#  MIT License
+#
+#  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+#  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+#  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#  OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Module for handling ``sysconfig`` based network managers.
+"""
+import click
+
+from crucible.network.manager import SystemNetwork
+
+from crucible.os import run_command
+from crucible.logger import Logger
+
+LOG = Logger(__name__)
+
+
+class NetworkManager(SystemNetwork):
+
+    """
+    Abstraction of NetworkManager.
+    """
+
+    name = "NetworkManager"
+    install_location = f'/etc/{name}/system-connections'
+
+    def __str__(self):
+        """
+        Name of the network manager.
+        """
+        return self.name
+
+    def update_dns(self) -> None:
+        """
+        Updates the system's static DNS list.
+        """
+        raise NotImplementedError('DNS updates for nmcli are not yet implemented.')
+
+    def update_search(self) -> None:
+        """
+        Updates the system's static DNS list.
+        """
+        raise NotImplementedError('Search updates for nmcli are not yet implemented.')
+
+    def reload_interface(self) -> None:
+        """
+        Loads new network interface configuration.
+        """
+        run_command(['nmcli', 'connection', 'reload', self.interface.name])
+        result = run_command(['ip', 'l', 'show', self.interface.name])
+        if result.return_code != 0:
+            LOG.error('Failed to reload %s', self.interface.name)
+
+    def remove_config(self) -> None:
+        """
+        Removes a network interface configuration.
+        """
+        run_command(['rm', f'{self.install_location}/*-{self.interface.name}'])
+        self.reload_interface()
+
+    def write_config(self) -> None:
+        """
+        Write a string to file, prompting the user to overwrite if the file
+        already exists.
+        """
+        if self.interface.vlan_id != 0:
+            run_command(
+                [
+                    'nmcli', 'connection', 'add', 'type', 'vlan',
+                    'ifname', self.interface.name,
+                    'dev', self.interface.members[0],
+                    'id', self.interface.vlan_id,
+                ]
+            )
+        elif self.interface.is_bond():
+            bond_opts = [f'{key}={value}' for key, value in
+                         self.interface.bond_opts.items()]
+            run_command(
+                ['nmcli', 'connection', 'add', 'type', 'bond',
+                 'ifname', self.interface.name,
+                 'bond.options', ','.join(bond_opts)]
+            )
+            for member in self.interface.members:
+                run_command(
+                    ['nmcli', 'connection', 'add', 'type', 'ethernet',
+                     'ifname', member,
+                     'master', self.interface.name]
+                )
+
+        click.echo(f'Created connections for: {self.interface.name}')
+        click.echo('See `nmcli connection` for status.')

--- a/crucible/scripts/ifnames.sh
+++ b/crucible/scripts/ifnames.sh
@@ -22,6 +22,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+echo >&2 'DEPRECATED! Use `crucible network udev` instead of invoking this script. This script is NOT maintained.'
 trap cleanup EXIT ERR
 hsnID=0
 lanID=0

--- a/crucible/scripts/wipe.sh
+++ b/crucible/scripts/wipe.sh
@@ -22,7 +22,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# TODO: Rewrite script in Python
+# TODO: Rewrite script in Python or Go.
 trap disclaimer ERR
 DRY_RUN=1
 
@@ -113,7 +113,7 @@ if [ "${DRY_RUN}" -ne 0 ]; then
 fi
 
 mkdir -p /var/log/crucible/
-exec 2>"/var/log/crucible/$(basename $0).err"
+exec 2>"/var/log/crucible/$(basename "$0").err"
 
 if [ -n "$root_disk" ]; then
     if [[ "$doomed_disks" =~ .*"/dev/${root_disk}".* ]]; then
@@ -154,6 +154,7 @@ for doomed_disk in $doomed_disks; do
     lsblk "$doomed_disk"
 done
 
+sleep 5
 for raid in /dev/md*; do
     mdadm --stop "$raid"
 done

--- a/crucible/scripts/wipe.sh
+++ b/crucible/scripts/wipe.sh
@@ -154,4 +154,8 @@ for doomed_disk in $doomed_disks; do
     lsblk "$doomed_disk"
 done
 
+for raid in /dev/md*; do
+    mdadm --stop "$raid"
+done
+
 echo 'local storage disk wipe complete'

--- a/crucible/scripts/write-livecd.sh
+++ b/crucible/scripts/write-livecd.sh
@@ -23,7 +23,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # Do not 'set -euo pipefail', this script will probably break.
-# TODO: Rewrite in Python.
+# TODO: Rewrite script in Python or Go.
 name=$(basename $0)
 
 # Size in MB to use for cow partition

--- a/crucible/tests/network/test_ifname.py
+++ b/crucible/tests/network/test_ifname.py
@@ -97,6 +97,11 @@ class MockCLI:
     return_code = None
     duration = None
 
+    def decode(self, **_):
+        """
+        Mocks ``_CLI.decode()``
+        """
+
 
 def mock_ethtool(*args, **_) -> MockCLI:
     """
@@ -107,6 +112,7 @@ def mock_ethtool(*args, **_) -> MockCLI:
     mock_cli = MockCLI()
     mac = mock_nics[nic]['mac']
     mock_cli.stdout = f'Permanent address: {mac}'
+    mock_cli.decode = mock.Mock()
     return mock_cli
 
 

--- a/crucible/tests/network/test_sysconfig.py
+++ b/crucible/tests/network/test_sysconfig.py
@@ -141,8 +141,7 @@ NETCONFIG_DNS_STATIC_SEARCHLIST="foo bar"
         ):
             self.network_manager.interface.name = 'mgmt0'
             self.network_manager.interface.dhcp = True
-            self.network_manager.write_config('ifcfg')
-            self.network_manager.write_config('ifroute')
+            self.network_manager.write_config()
             # TODO: Test written files.
 
     def test_write_config_static(self) -> None:
@@ -155,8 +154,7 @@ NETCONFIG_DNS_STATIC_SEARCHLIST="foo bar"
             self.network_manager.interface.name = 'lan0'
             self.network_manager.interface.ipaddr = '192.168.1.2/24'
             self.network_manager.interface.is_default_route = True
-            self.network_manager.write_config('ifcfg')
-            self.network_manager.write_config('ifroute')
+            self.network_manager.write_config()
             # TODO: Test written files.
 
     def test_write_config_bond(self) -> None:
@@ -169,8 +167,7 @@ NETCONFIG_DNS_STATIC_SEARCHLIST="foo bar"
             self.network_manager.interface.name = 'bond0'
             self.network_manager.interface.ipaddr = '192.168.1.2/24'
             self.network_manager.interface.members = ['mgmt0', 'mgmt1']
-            self.network_manager.write_config('ifcfg')
-            self.network_manager.write_config('ifroute')
+            self.network_manager.write_config()
             # TODO: Test written files.
 
     def test_write_config_bridge(self) -> None:
@@ -183,8 +180,7 @@ NETCONFIG_DNS_STATIC_SEARCHLIST="foo bar"
             self.network_manager.interface.name = 'virbr0'
             self.network_manager.interface.ipaddr = '192.168.1.2/24'
             self.network_manager.interface.members = ['bond0']
-            self.network_manager.write_config('ifcfg')
-            self.network_manager.write_config('ifroute')
+            self.network_manager.write_config()
             # TODO: Test written files.
 
     def test_write_config_vlan(self) -> None:
@@ -198,6 +194,5 @@ NETCONFIG_DNS_STATIC_SEARCHLIST="foo bar"
             self.network_manager.interface.ipaddr = '192.168.1.2/24'
             self.network_manager.interface.vlan_id = 2
             self.network_manager.interface.members = ['bond0']
-            self.network_manager.write_config('ifcfg')
-            self.network_manager.write_config('ifroute')
+            self.network_manager.write_config()
             # TODO: Test written files.

--- a/crucible/tests/test_cli.py
+++ b/crucible/tests/test_cli.py
@@ -132,36 +132,6 @@ class TestCLI:
         assert mock_run.called
 
     @mock.patch('crucible.install.run_command', spec=True, return_code=0)
-    def test_install_small_sqfs_storage(self, mock_run) -> None:
-        """
-        Tests that a warning is emitted if a small squashFS storage size is
-        given.
-        """
-        result = self.runner.invoke(
-            crucible,
-            [
-                'install',
-                '--sqfs-storage-size=3',
-            ],
-        )
-        assert result.exit_code == 0
-        assert mock_run.called
-
-    def test_install_no_sqfs_storage(self) -> None:
-        """
-        Tests that the ``install`` command fails if the squashFS storage
-        is too small.
-        """
-        result = self.runner.invoke(
-            crucible,
-            [
-                'install',
-                '--sqfs-storage-size=0',
-            ],
-        )
-        assert result.exit_code != 0
-
-    @mock.patch('crucible.install.run_command', spec=True, return_code=0)
     def test_install_stripe(self, mock_run) -> None:
         """
         Tests that the ``install`` command does not fail if a stripe is given.

--- a/crucible/vms.py
+++ b/crucible/vms.py
@@ -34,7 +34,7 @@ from crucible.logger import Logger
 
 LOG = Logger(__name__)
 directory = os.path.dirname(__file__)
-vm_script = os.path.join(directory, '..', 'scripts', 'management-vm.sh')
+vm_script = os.path.join(directory, 'scripts', 'management-vm.sh')
 
 
 def start(capacity: int, interface: str, ssh_key_path: str) -> None:
@@ -45,7 +45,7 @@ def start(capacity: int, interface: str, ssh_key_path: str) -> None:
                      storage (default 100).
     :param interface: The interface for external networking (default lan0)
     :param ssh_key_path: The path to the SSH key for the VM's root user
-                         (default: /root/.ssh/id_rsa.pub)
+                         (default: /root/.ssh/)
     """
 
     args = [vm_script]
@@ -57,9 +57,11 @@ def start(capacity: int, interface: str, ssh_key_path: str) -> None:
         args.extend(['-s', ssh_key_path])
     click.echo('Starting management VM ... ')
     result = run_command(args, in_shell=True)
+    LOG.info(vars(result))
     if result.return_code != 0:
-        LOG.critical('Failed to start the management VM! Check logs.')
-    click.echo('Management VM started.')
+        click.echo('Failed to start the management VM! Check logs.')
+    else:
+        click.echo('Management VM started.')
 
 
 def reset() -> None:
@@ -70,5 +72,7 @@ def reset() -> None:
     click.echo('Purging/resetting management VM ... ')
     result = run_command(args, in_shell=True)
     if result.return_code != 0:
-        LOG.critical('Failed cleanup the management VM! Check logs.')
-    click.echo('Management VM was purged.')
+        click.echo('Failed cleanup the management VM! Check logs and'
+                   'then run the `reset` subcommand before trying again.')
+    else:
+        click.echo('Management VM was purged.')


### PR DESCRIPTION
- [networkmanager] *New* `NetworkManager` support, namely:
  - Ability to set DNS per interface
  - Ability to create an interface with no IP, DHCP, or a static IP
  - Ability to setup bond, VLAN, and ethernet interfaces
  - Ability to (crudely) remove interfaces
- [wicked] `write_config` no longer needs an argument
- [network] module now resolves between `wicked` and `NetworkManager` based on the current active `network.service` target.
- [install] *New* support for ISO installations
- [install] *Removed* support for squashFS installations
- [install] *New* support for installing SSH keys
- [install] Fixed many minor bugs
- [install] *New* support for master nodes; new value for "large disks" allows the third disk on CSM master nodes to be used for VMs
- [wipe] Updated RAID stop code to handle (some) loose ends
- [vm] Fixed `start` command, it now works
- [general] Some more logging statements were added

*NOTE* `NetworkManager` support is only partial, there will be bugs.