### PR TITLE
Cloud init networking

### DIFF
--- a/crucible/cli.py
+++ b/crucible/cli.py
@@ -373,7 +373,28 @@ def vm() -> None:
     type=str,
     is_flag=False,
     help="Path to an SSH public key, or a directory of keys to install into "
-         "the management VM",
+         "the management VM.",
+)
+@click.option(
+    '-I',
+    '--ip-address',
+    type=str,
+    is_flag=False,
+    help="The IP address in CIDR notation for assigning to the management VM.",
+)
+@click.option(
+    '-d',
+    '--dns',
+    type=str,
+    is_flag=False,
+    help="A comma delimited list of DNS servers to set up in the management VM.",
+)
+@click.option(
+    '-S',
+    '--system-name',
+    type=str,
+    is_flag=False,
+    help="A handle for the system, a recognizable name/alias.",
 )
 def start(**kwargs) -> None:
     """

--- a/crucible/network/manager.py
+++ b/crucible/network/manager.py
@@ -53,10 +53,11 @@ class InterfaceError(Exception):
 
 
 default_bond_opts = {
+    'ad_select': 'bandwidth',
     'mode': '802.3ad',
     'miimon': 100,
     'lacp_rate': 'fast',
-    'xmit_hash_policy': 'layer2+3',
+    'xmit_hash_policy': 'layer2',
 }
 
 

--- a/crucible/scripts/management-vm.sh
+++ b/crucible/scripts/management-vm.sh
@@ -30,6 +30,11 @@ CAPACITY=100
 MGMTCLOUD=/vms/cloud-init/management-vm
 INTERFACE=lan0
 SSH_KEY=/root/.ssh/
+
+SITE_CIDR=''
+DNS=''
+SYSTEM_NAME=''
+
 RESET=0
 error=0
 required_programs=( "yq" "xorriso" "virsh" )
@@ -49,11 +54,14 @@ function usage {
 -r      Resets the management VM. Destroys all volumes, pools, and the management virtual machine. Resets the cloud-init ISO.
 -s      SSH_KEY path to install into the management VM's root user (default: /root/.ssh/id_rsa.pub)
 -i      INTERFACE to use for the Management external network (default: lan0).
+-I      IP address to use for the management VM's external interface
+-d      DNS servers (a comma delimited string) to use
+-S      System name
 EOF
 exit 0
 }
 
-while getopts ":rc:s:i:" o; do
+while getopts ":rc:s:i:I:d:S:" o; do
     case "${o}" in
         c)
             CAPACITY="${OPTARG}"
@@ -67,6 +75,16 @@ while getopts ":rc:s:i:" o; do
         s)
             SSH_KEY="${OPTARG}"
             ;;
+        I)
+            SITE_CIDR="${OPTARG}"
+            ;;
+        d)
+            IFS=$',' read -ra SITE_DNS <<< "$DNS"
+            unset IFS
+            ;;
+        S)
+            SYSTEM_NAME="${OPTARG}"
+            ;;
         *)
             usage
             ;;
@@ -76,20 +94,23 @@ shift $((OPTIND-1))
 
 if [ "$RESET" -eq 1 ]; then
     virsh destroy management-vm || echo 'Already destroyed ... '
+    virsh undefine management-vm || echo 'Already undefined ... '
     virsh vol-delete --pool management-pool management-vm.qcow2 || echo 'Volume already deleted ... '
     virsh pool-destroy management-pool || echo 'Pool already destroyed ... '
     virsh pool-undefine management-pool || echo 'Pool already undefined ... '
     virsh net-destroy isolated || echo 'Isolated network already destroyed ... '
     virsh net-undefine isolated || echo 'Isolated network already undefined ... '
-    cp -p /run/rootfsbase/srv/cray/bootstrap/user-data "${MGMTCLOUD}/user-data"
-    cp -p /run/rootfsbase/srv/cray/bootstrap/domain.xml "${BOOTSTRAP}/domain.xml"
+    cp -p /run/rootfsbase/srv/cray/bootstrap/meta-data "${MGMTCLOUD}/meta-data" || true
+    cp -p /run/rootfsbase/srv/cray/bootstrap/user-data "${MGMTCLOUD}/user-data" || true
+    cp -p /run/rootfsbase/srv/cray/bootstrap/network-config "${MGMTCLOUD}/network-config" || true
+    cp -p /run/rootfsbase/srv/cray/bootstrap/domain.xml "${BOOTSTRAP}/domain.xml" || true
     rm -f "${MGMTCLOUD}/cloud-init.iso"
     echo "Management VM was purged, bootstrap files were reset."
     exit 0
 fi
 
 mkdir -p "${MGMTCLOUD}"
-cp -p "$BOOTSTRAP/meta-data" "${BOOTSTRAP}/user-data" ${MGMTCLOUD}
+cp -p "$BOOTSTRAP/meta-data" "${BOOTSTRAP}/user-data" "${BOOTSTRAP}/network-config" ${MGMTCLOUD}
 
 if [ -f "$SSH_KEY" ]; then
     yq -i eval '(.users.[] | select(.name = "root") | .ssh_authorized_keys) += "'"$(cat "$SSH_KEY")"'"' "${MGMTCLOUD}/user-data"
@@ -108,7 +129,8 @@ xorriso -as genisoimage \
     -output "${MGMTCLOUD}/cloud-init.iso" \
     -volid CIDATA -joliet -rock -f \
     "${MGMTCLOUD}/user-data" \
-    "${MGMTCLOUD}/meta-data"
+    "${MGMTCLOUD}/meta-data" \
+    "${MGMTCLOUD}/network-config"
 
 virsh pool-define-as management-pool dir --target /var/lib/libvirt/management-pool
 virsh pool-build management-pool
@@ -127,8 +149,30 @@ virsh net-autostart isolated || echo 'Already auto-started'
 yq --xml-attribute-prefix='+@' -i -o xml -p xml eval '.domain.devices.interface |= [
 {"+@type": "network", "source": {"+@network": "isolated"}, "model": {"+@type": "virtio"}},
 {"+@type": "direct", "source": {"+@dev": "bond0", "+@mode": "bridge"}, "model": {"+@type": "virtio"}},
+{"+@type": "direct", "source": {"+@dev": "bond0.hmn0", "+@mode": "bridge"}, "model": {"+@type": "virtio"}},
 {"+@type": "direct", "source": {"+@dev": "'"$INTERFACE"'", "+@mode": "bridge"}, "model": {"+@type": "virtio"}}
 ]' "${BOOTSTRAP}/domain.xml"
+
+if [ -z "$SYSTEM_NAME" ]; then
+    :
+else
+    yq -i eval '.local-hostname = "'"$SYSTEM_NAME"'-management"' "${BOOTSTRAP}/meta-data"
+fi
+yq -i eval '.network.ethernets.eth1 = {"dhcp4": false, "dhcp6": false, "mtu": 9000, "addresses": ["10.1.1.1/16"]}' "${BOOTSTRAP}/network-config"
+yq -i eval '.network.ethernets.eth2 = {"dhcp4": false, "dhcp6": false, "mtu": 9000, "addresses": ["10.254.1.1/17"]}' "${BOOTSTRAP}/network-config"
+if [ -z "$SITE_CIDR" ]; then
+    echo >&2 'No SITE_CIDR was provided, the external interface will not be assigned an IP address and will rely on DHCP.'
+    yq -i eval '.network.ethernets.eth3 = {"dhcp4": true, "dhcp6": false, "mtu": 1500}' "${BOOTSTRAP}/network-config"
+else
+    yq -i eval '.network.ethernets.eth3 = {"dhcp4": false, "dhcp6": false, "mtu": 1500, "addresses": ["'"${SITE_CIDR}"'"]}' "${BOOTSTRAP}/network-config"
+fi
+if [ "${#SITE_DNS[@]}" -eq 0 ]; then
+    echo >&2 'No SITE_DNS was provided, no static nameservers will be configured.'
+else
+    for dns in "${SITE_DNS[@]}"; do
+        yq -i eval '.network.ethernets.eth3.nameservers.addresses += ["'"$dns"'"]' "${BOOTSTRAP}/network-config"
+    done
+fi
 
 virsh create "${BOOTSTRAP}/domain.xml"
 
@@ -136,4 +180,9 @@ cat << EOF
 Management VM created ... observe its launch with:
 
     virsh console management-vm
+
+Once the VM is up and cloud-int has printed that it has finished running, SSH to the VM with:
+
+    ssh ${SITE_CIDR%/*}
+
 EOF

--- a/crucible/vms.py
+++ b/crucible/vms.py
@@ -37,24 +37,38 @@ directory = os.path.dirname(__file__)
 vm_script = os.path.join(directory, 'scripts', 'management-vm.sh')
 
 
-def start(capacity: int, interface: str, ssh_key_path: str) -> None:
+def start(system_name: str = None, **kwargs) -> None:
     """
     Starts the management VM.
 
-    :param capacity: Capacity (in Gigabytes) for the management VM
+    :param system_name: The name of the system, a more recognizable handle.
+    :keyword capacity: Capacity (in Gigabytes) for the management VM
                      storage (default 100).
-    :param interface: The interface for external networking (default lan0)
-    :param ssh_key_path: The path to the SSH key for the VM's root user
+    :keyword interface: The interface for external networking (default lan0)
+    :keyword ssh_key_path: The path to the SSH key for the VM's root user
                          (default: /root/.ssh/)
+    :keyword ip_address: The CIDR to assign to the external interface in the management VM
+    :keyword dns: A comma delimited list of DNS servers to assign to the management VM
     """
 
     args = [vm_script]
+    capacity = kwargs.get('capacity')
+    dns = kwargs.get('dns')
+    interface = kwargs.get('interface')
+    ip_address = kwargs.get('ip_address')
+    ssh_key_path = kwargs.get('ssh_key_path')
     if capacity:
         args.extend(['-c', capacity])
     if interface:
         args.extend(['-i', interface])
     if ssh_key_path:
         args.extend(['-s', ssh_key_path])
+    if ip_address:
+        args.extend(['-I', ip_address])
+    if dns:
+        args.extend(['-d', dns])
+    if system_name:
+        args.extend(['-S', system_name])
     click.echo('Starting management VM ... ')
     result = run_command(args, in_shell=True)
     LOG.info(vars(result))


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

#### Issue Type

<!--- Delete un-needed bullets; choose one or more.  -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
- Adds a new `network-config` file to the cloud-init ISO for facilitating initial hypervisor installs.
- MTL-2261 switches the bond to `layer2`
- Adds `ad_select` mode `bandwidth`
- Invokes `nmcli` with `con-name` when creating interfaces for deterministic NetworkManager connection names

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required).
- [ ] I have added unit tests for my code.
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
