### PR TITLE
Minor adjustments and fixes for `management-vm.sh` and grub

### DIFF
--- a/crucible/cli.py
+++ b/crucible/cli.py
@@ -383,6 +383,13 @@ def vm() -> None:
     help="The IP address in CIDR notation for assigning to the management VM.",
 )
 @click.option(
+    '-g',
+    '--gateway',
+    type=str,
+    is_flag=False,
+    help="The IP address for the default route.",
+)
+@click.option(
     '-d',
     '--dns',
     type=str,

--- a/crucible/scripts/install.sh
+++ b/crucible/scripts/install.sh
@@ -506,7 +506,7 @@ function setup_bootloader {
         disk_cmdline+=( "root=live:LABEL=$iso_label" )
     # Make our grub.cfg file.
         cat << EOF > "${mpoint}/boot/grub2/grub.cfg"
-set timeout=10
+set timeout=5
 set default=0 # Set the default menu entry
 menuentry "$name" --class gnu-linux --class gnu {
     set gfxpayload=keep
@@ -535,7 +535,7 @@ EOF
         cp "/run/initramfs/live/boot/$arch/loader/initrd.img.xz" "${mpoint}/${live_dir}/"
         disk_cmdline+=( "root=live:LABEL=${boot_drive_authority}" )
         cat << EOF > "${mpoint}/boot/grub2/grub.cfg"
-set timeout=10
+set timeout=5
 set default=0 # Set the default menu entry
 menuentry "$name" --class gnu-linux --class gnu {
     set gfxpayload=keep

--- a/crucible/scripts/install.sh
+++ b/crucible/scripts/install.sh
@@ -584,7 +584,7 @@ function setup_overlayfs {
     fi
     if [ "$error" -ne 0 ]; then
         rm -rf "$mpoint"
-        return 1
+        error=1
     fi
 
     # Create OverlayFS directories for dmsquash-live
@@ -595,7 +595,7 @@ function setup_overlayfs {
         overlayfs_spec="$(_find_boot_disk_overlayfs_spec)"
     else
         echo >&2 'Error! No overlayFS spec was found for the rootfs partition.'
-        return 1
+        error=1
     fi
     mkdir -v -p \
         "${mpoint}/${live_dir}/${overlayfs_spec}" \
@@ -665,11 +665,11 @@ EOF
     elif [ -f /etc/hypervisor-release ]; then
         if [ "$ssh_import_exit_code" -ne 0 ]; then
             echo >&2 'SSH key auto-import failed! See ssh-import-id.service for more information.'
-            return 1
+            error=1
         fi
         if [ ! -f /root/.ssh/authorized_keys ]; then
             echo >&2 'No authorized_keys were defined for root, double-check the ssh-import-id.service.'
-            return 1
+            error=1
         fi
         cat /root/.ssh/authorized_keys >> "${mpoint}/${live_dir}/${overlayfs_spec}/root/.ssh/authorized_keys"
         chmod 600 "${mpoint}/${live_dir}/${overlayfs_spec}/root/.ssh/authorized_keys"

--- a/crucible/scripts/management-vm.sh
+++ b/crucible/scripts/management-vm.sh
@@ -32,7 +32,7 @@ INTERFACE=lan0
 SSH_KEY=/root/.ssh/
 
 SITE_CIDR=''
-DNS=''
+SITE_DNS=()
 SYSTEM_NAME=''
 
 RESET=0
@@ -79,7 +79,7 @@ while getopts ":rc:s:i:I:d:S:" o; do
             SITE_CIDR="${OPTARG}"
             ;;
         d)
-            IFS=$',' read -ra SITE_DNS <<< "$DNS"
+            IFS=$',' read -ra SITE_DNS <<< "${OPTARG}"
             unset IFS
             ;;
         S)
@@ -125,12 +125,6 @@ else
     echo >&2 "SSH Key at [$SSH_KEY] was not found."
     exit 1
 fi
-xorriso -as genisoimage \
-    -output "${MGMTCLOUD}/cloud-init.iso" \
-    -volid CIDATA -joliet -rock -f \
-    "${MGMTCLOUD}/user-data" \
-    "${MGMTCLOUD}/meta-data" \
-    "${MGMTCLOUD}/network-config"
 
 virsh pool-define-as management-pool dir --target /var/lib/libvirt/management-pool
 virsh pool-build management-pool
@@ -173,6 +167,13 @@ else
         yq -i eval '.network.ethernets.eth3.nameservers.addresses += ["'"$dns"'"]' "${BOOTSTRAP}/network-config"
     done
 fi
+
+xorriso -as genisoimage \
+    -output "${MGMTCLOUD}/cloud-init.iso" \
+    -volid CIDATA -joliet -rock -f \
+    "${MGMTCLOUD}/user-data" \
+    "${MGMTCLOUD}/meta-data" \
+    "${MGMTCLOUD}/network-config"
 
 virsh create "${BOOTSTRAP}/domain.xml"
 

--- a/crucible/vms.py
+++ b/crucible/vms.py
@@ -27,6 +27,7 @@ Module for launching VMs.
 import os
 
 import click
+from netaddr import IPNetwork
 
 from crucible.os import run_command
 from crucible.logger import Logger
@@ -48,6 +49,7 @@ def start(system_name: str = None, **kwargs) -> None:
     :keyword ssh_key_path: The path to the SSH key for the VM's root user
                          (default: /root/.ssh/)
     :keyword ip_address: The CIDR to assign to the external interface in the management VM
+    :keyword gateway:
     :keyword dns: A comma delimited list of DNS servers to assign to the management VM
     """
 
@@ -56,6 +58,7 @@ def start(system_name: str = None, **kwargs) -> None:
     dns = kwargs.get('dns')
     interface = kwargs.get('interface')
     ip_address = kwargs.get('ip_address')
+    gateway = kwargs.get('gateway')
     ssh_key_path = kwargs.get('ssh_key_path')
     if capacity:
         args.extend(['-c', capacity])
@@ -65,6 +68,10 @@ def start(system_name: str = None, **kwargs) -> None:
         args.extend(['-s', ssh_key_path])
     if ip_address:
         args.extend(['-I', ip_address])
+        if gateway:
+            args.extend(['-g', gateway])
+        else:
+            args.extend(['-g', str(IPNetwork(ip_address)[1])])
     if dns:
         args.extend(['-d', dns])
     if system_name:

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,2 +1,3 @@
 * xref:index.adoc[]
 * xref:nic-configuration.adoc[]
+* xref:nic-interfaces-setup-reference.adoc[]

--- a/docs/modules/ROOT/pages/nic-interfaces-setup-reference.adoc
+++ b/docs/modules/ROOT/pages/nic-interfaces-setup-reference.adoc
@@ -1,0 +1,169 @@
+= Network Interface Setup Reference
+:toc:
+:toclevels: 3
+
+This page provides a quick reference for `crucible` and `nmcli`.
+
+NOTE: The `nmcli` commands are provided as backup options when `crucible` fails.
+
+== Hypervisor Nodes (without VxLAN)
+
+=== Bond setup
+
+`crucible`::
+* First hypervisor
++
+[source,bash]
+----
+crucible network interface \
+    --dhcp \
+    bond0 \
+    --members mgmt0,mgmt1 \
+    --mtu 9000
+----
+* Remaining hypervisors
++
+[source,bash]
+----
+crucible network interface \
+    --noip \
+    bond0 \
+    --members mgmt0,mgmt1 \
+    --mtu 9000
+----
+`nmcli`::
++
+[source,bash]
+----
+nmcli connection add \
+    con-name bond0 \
+    type bond \
+    ifname bond0 \
+    bond.options "mode=802.3ad,miimon=100,lacp_rate=fast,xmit_hash_policy=layer2,ad_select=bandwidth" \
+    ethernet.mtu 9000 \
+    ipv4.method disabled \
+    ipv6.method disabled
+nmcli connection add \
+    con-name mgmt0 \
+    type ethernet \
+    ifname mgmt0 \
+    master bond0 \
+    ethernet.mtu 9000
+nmcli connection add \
+    con-name mgmt1 \
+    type ethernet \
+    ifname mgmt1 \
+    master bond0 \
+    ethernet.mtu 9000
+nmcli connection up mgmt1
+nmcli connection up mgmt0
+----
+
+=== VLAN setup
+
+`crucible`::
++
+[source,bash]
+----
+crucible network interface \
+    --noip bond0.nmn0 \
+    --vlan-id 2 \
+    --members bond0 \
+    --mtu 9000
+crucible network interface \
+    --noip bond0.hmn0 \
+    --vlan-id 4 \
+    --members bond0 \
+    --mtu 9000
+crucible network interface \
+    --noip bond0.cmn0 \
+    --vlan-id 7 \
+    --members bond0 \
+    --mtu 9000
+----
+`nmcli`::
++
+[source,bash]
+----
+nmcli connection add \
+    con-name bond0.hmn0 \
+    type vlan \
+    ifname bond0.nmn0 \
+    dev bond0 \
+    id 2 \
+    ipv4.method disabled \
+    ethernet.mtu 9000 \
+    ipv6.method disabled
+nmcli connection add \
+    con-name bond0.hmn0 \
+    type vlan \
+    ifname bond0.hmn0 \
+    dev bond0 \
+    id 4 \
+    ipv4.method disabled \
+    ethernet.mtu 9000 \
+    ipv6.method disabled
+nmcli connection add \
+    con-name bond0.hmn0 \
+    type vlan \
+    ifname bond0.can0 \
+    dev bond0 \
+    id 4 \
+    ipv4.method disabled \
+    ethernet.mtu 9000 \
+    ipv6.method disabled
+----
++
+[source,bash]
+----
+nmcli connection up bond0.nmn0
+nmcli connection up bond0.hmn0
+nmcli connection up bond0.cmn0
+----
+
+=== LAN 0 setup (DHCP)
+
+`crucible`::
++
+[source,bash]
+----
+crucible network interface \
+    --dhcp \
+    lan0
+----
+`nmcli`::
++
+[source,bash]
+----
+nmcli connection add \
+    con-name lan0 \
+    type ethernet \
+    ifname lan0 \
+    ipv4.method auto \
+    ipv6.method disabled
+----
+
+=== LAN 0 setup (with IP)
+
+`crucible`::
++
+[source,bash]
+----
+crucible network interface \
+    lan0 \
+    10.100.254.5/24 \
+    --dns 16.110.135.51,16.110.135.52
+----
+`nmcli`::
++
+[source,bash]
+----
+nmcli connection add \
+    con-name lan0 \
+    type ethernet \
+    ifname lan0 \
+    ipv4.address 10.100.254.5/24 \
+    ipv4.dns 16.110.135.51,16.110.135.52 \
+    ipv4.method manual \
+    ipv6.method disabled
+----


### PR DESCRIPTION
- Shorter grub timeout, 5 seconds instead of 10
- Create cloud-init ISO after modifying all files, some file modification lines made it in after the `xorriso` call by accident. These went unnoticed because they pertained to the `network-config`, which wasn't working until now.
- Fix `SITE_DNS` undefined variable, remove unused `DNS` variable, and actually set `SITE_DNS` during script startup.
