### PR TITLE
Mgmt vm updates

### DIFF
--- a/crucible/os.py
+++ b/crucible/os.py
@@ -29,6 +29,8 @@ Module for handling command line calls.
    ``run_command``.
 
 """
+import sys
+
 from contextlib import contextmanager
 from time import time
 from subprocess import PIPE
@@ -51,7 +53,8 @@ class _CLI:
     _return_code = None
     _duration = None
 
-    def __init__(self, args: [str, list], shell: bool = False) -> None:
+    def __init__(self, args: [str, list], shell: bool = False,
+                 verbose: bool = False) -> None:
         """
         Create a ``Popen`` object.
 
@@ -62,7 +65,9 @@ class _CLI:
 
         :param args: The arguments (as a list or string) to run with Popen.
         :param shell: Whether to run Popen in a shell (default: False)
+        :param verbose: Whether to print stdout to the terminal.
         """
+        self.verbose = verbose
         if shell and isinstance(args, list):
             self.args = ' '.join(args)
         else:
@@ -84,8 +89,18 @@ class _CLI:
                     stdout=PIPE,
                     stderr=PIPE,
                     shell=self.shell,
-            ) as command:
-                stdout, stderr = command.communicate()
+            ) as process:
+                if self.verbose:
+                    while True:
+                        output = process.stdout.readline()
+                        if output == b'' and process.poll() is not None:
+                            break;
+                        if output:
+                            print(output.strip().decode(sys.stdout.encoding))
+                    stdout = process.stdout
+                    stderr = process.stderr
+                else:
+                    stdout, stderr = process.communicate()
         except IOError as error:
             self._stderr = error.strerror
             self._return_code = error.errno
@@ -94,7 +109,7 @@ class _CLI:
             try:
                 self._stdout = stdout
                 self._stderr = stderr
-                self._return_code = command.returncode
+                self._return_code = process.returncode
             except UnicodeDecodeError as error:
                 self._stderr = error
                 self._return_code = 1
@@ -201,6 +216,7 @@ def run_command(
         args: [list, str],
         in_shell: bool = False,
         silence: bool = False,
+        verbose: bool = False,
         charset: str = None,
 ) -> _CLI:
     """
@@ -215,7 +231,8 @@ def run_command(
 
     :param args: List of arguments to run, can also be a string. If a string,
     :param in_shell: Whether to use a shell when invoking the command.
-    :param silence: Tells this not to output the command to console.
+    :param silence: Tells this not to output the command to the log.
+    :param verbose: Tells this to output stdout to the console.
     :param charset: Returns the command ``stdout`` and ``stderr`` as a
                     string instead of bytes, and decoded with the given
                     ``charset``.
@@ -227,7 +244,7 @@ def run_command(
             ' '.join(args_string),
             in_shell
         )
-    result = _CLI(args_string, shell=in_shell)
+    result = _CLI(args_string, shell=in_shell, verbose=verbose)
     if charset:
         result.decode(charset)
     return result

--- a/crucible/os.py
+++ b/crucible/os.py
@@ -94,7 +94,7 @@ class _CLI:
                     while True:
                         output = process.stdout.readline()
                         if output == b'' and process.poll() is not None:
-                            break;
+                            break
                         if output:
                             print(output.strip().decode(sys.stdout.encoding))
                     stdout = process.stdout

--- a/crucible/scripts/management-vm.sh
+++ b/crucible/scripts/management-vm.sh
@@ -225,6 +225,7 @@ while ! ssh-keyscan -T 1 -H management-vm.local management-vm >> /root/.ssh/know
     seconds="$(("$seconds" + 1))"
     sleep 1
 done
+echo "'Waited for ${seconds} second${plural:+s}"
 echo -e '\nManagement VM is online.'
 if [ -n "$SITE_CIDR" ]; then
     echo -en 'Login to the management-vm externally with:\n\n'

--- a/crucible/scripts/management-vm.sh
+++ b/crucible/scripts/management-vm.sh
@@ -154,14 +154,17 @@ cat "$SSH_TEMP/deployment_id.pub" >> /root/.ssh/authorized_keys
 rm -rf "$SSH_TEMP"
 
 virsh pool-define-as management-pool dir --target /var/lib/libvirt/management-pool
-virsh pool-build management-pool
-virsh pool-start management-pool
+virsh pool-start --build management-pool
 virsh pool-autostart management-pool
 
-virsh vol-create-as --pool management-pool --name management-vm.qcow2 "${CAPACITY}G" --prealloc-metadata --format qcow2
+# Hack around the capacity. The alloc ends up being .02 GB higher than the capacity, and after we vol-upload the capacity drops to ~20.
+# We can't set the capcity to CAPACITY afterwards due to the ALLOC being .02 higher, so we just set the CAPACITY to be minus one beforehand.
+# This way, the ending capacity will match what the user specified.
+virsh vol-create-as --pool management-pool --name management-vm.qcow2 "$((CAPACITY - 1))}G" --prealloc-metadata --format qcow2
 management_vm_image=''
 management_vm_image="$(find /vms/assets -name "management-vm*.qcow2")"
-virsh vol-upload --sparse --pool management-pool management-vm.qcow2 "${management_vm_image}"
+virsh vol-upload --sparse --pool management-pool management-vm.qcow2 --file "${management_vm_image}"
+virsh vol-resize --pool management-pool management-vm.qcow2 $((CAPACITY))G
 
 virsh net-define "${BOOTSTRAP}/isolated.xml"
 virsh net-start isolated || echo 'Already started'

--- a/crucible/vms.py
+++ b/crucible/vms.py
@@ -77,12 +77,12 @@ def start(system_name: str = None, **kwargs) -> None:
     if system_name:
         args.extend(['-S', system_name])
     click.echo('Starting management VM ... ')
-    result = run_command(args, in_shell=True)
+    result = run_command(args, in_shell=True, verbose=True)
     LOG.info(vars(result))
     if result.return_code != 0:
         click.echo('Failed to start the management VM! Check logs.')
     else:
-        click.echo('Management VM started.')
+        click.echo('Done.')
 
 
 def reset() -> None:
@@ -91,9 +91,9 @@ def reset() -> None:
     """
     args = [vm_script, '-r']
     click.echo('Purging/resetting management VM ... ')
-    result = run_command(args, in_shell=True)
+    result = run_command(args, in_shell=True, verbose=True)
     if result.return_code != 0:
         click.echo('Failed cleanup the management VM! Check logs and'
                    'then run the `reset` subcommand before trying again.')
     else:
-        click.echo('Management VM was purged.')
+        click.echo('Done.')

--- a/docs/modules/ROOT/pages/nic-interfaces-setup-reference.adoc
+++ b/docs/modules/ROOT/pages/nic-interfaces-setup-reference.adoc
@@ -16,7 +16,7 @@ NOTE: The `nmcli` commands are provided as backup options when `crucible` fails.
 [source,bash]
 ----
 crucible network interface \
-    --dhcp \
+    --noip \
     bond0 \
     --members mgmt0,mgmt1 \
     --mtu 9000
@@ -26,7 +26,7 @@ crucible network interface \
 [source,bash]
 ----
 crucible network interface \
-    --noip \
+    --dhcp \
     bond0 \
     --members mgmt0,mgmt1 \
     --mtu 9000


### PR DESCRIPTION
More changes from the run-through and demo.

- Auto-generate the SSH deployment key
- Fixes the management-VM's disk capacity, which was coming up at ~20GB instead of the specified 100GB
- Auto-adds the generated SSH key to the management-vm's root user
- Auto-adds the ssh fingerprint of the management-vm to the hypervisor, and vice-versa
- Auto-adds the generated SSH public key to the hypervisor's authorized keys
- More verbose output when running `crucible vm [start,reset]`
- `management-vm.sh` waits until SSH is usable on the management-vm before exiting