### PR TITLE
Update RPM in the OverlayFS and Run-through Fixes

### DIFF
--- a/crucible/network/ifname.yml
+++ b/crucible/network/ifname.yml
@@ -21,3 +21,5 @@ mgmt_ids:
     vendor_id: '1077'
   - memo: Solarflare
     vendor_id: '1924'
+  - memo: Broadcom
+    vendor_id: '14e4'

--- a/crucible/scripts/install.sh
+++ b/crucible/scripts/install.sh
@@ -413,7 +413,6 @@ _mount_overlayfs() {
     echo "${temp}/overlayfs"
 }
 
-
 ##############################################################################
 # function: _umount_overlayfs
 #

--- a/crucible/scripts/install.sh
+++ b/crucible/scripts/install.sh
@@ -24,6 +24,13 @@
 #
 # Do not 'set -euo pipefail', this script will probably break.
 # TODO: Rewrite script in Python or Go.
+LOG_DIR="/var/log/crucible/install"
+CURRENT_LOG_DIR="${LOG_DIR}/$(date '+%Y-%m-%d_%H:%M:%S')"
+mkdir -p "${CURRENT_LOG_DIR}"
+exec 19>"${CURRENT_LOG_DIR}/patch.xtrace"
+export BASH_XTRACEFD="19"
+set -o xtrace
+exec 2>"${CURRENT_LOG_DIR}/stderr.log"
 
 mount -L data
 mkdir /data/logs
@@ -72,9 +79,6 @@ METAL_SUBSYSTEMS='scsi|nvme'
 # excluded from any operations performed by this dracut module.
 # NOTE: To find values for this, run `lsblk -b -l -d -o SIZE,NAME,TYPE,SUBSYSTEMS`
 METAL_SUBSYSTEMS_IGNORE='usb'
-
-LOG="/var/log/crucible/$(basename $0).log"
-true >"${LOG}"
 
 boot_drive_scheme=LABEL
 boot_drive_authority=BOOTRAID

--- a/crucible/scripts/management-vm.sh
+++ b/crucible/scripts/management-vm.sh
@@ -164,6 +164,10 @@ if virsh pool-define-as management-pool dir --target "${STORE}/pools/fawkes-mana
     virsh vol-create-as --pool management-pool --name management-vm.qcow2 "$((CAPACITY - 1))G" --prealloc-metadata --format qcow2
     management_vm_image=''
     management_vm_image="$(find /vms/store0/assets -name "management-vm*.qcow2")"
+    if [ -z "$management_vm_image" ]; then
+        echo >&2 "VM image was not found! Tar ball was not extracted into /vms/store0/assets/"
+        exit 1
+    fi
     virsh vol-upload --sparse --pool management-pool management-vm.qcow2 --file "${management_vm_image}"
     virsh vol-resize --pool management-pool management-vm.qcow2 "${CAPACITY}G"
 fi

--- a/crucible/scripts/wipe.sh
+++ b/crucible/scripts/wipe.sh
@@ -23,6 +23,14 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # TODO: Rewrite script in Python or Go.
+LOG_DIR="/var/log/crucible/wipe"
+CURRENT_LOG_DIR="${LOG_DIR}/$(date '+%Y-%m-%d_%H:%M:%S')"
+mkdir -p "${CURRENT_LOG_DIR}"
+exec 19>"${CURRENT_LOG_DIR}/patch.xtrace"
+exec 2>"${CURRENT_LOG_DIR}/stderr.log"
+export BASH_XTRACEFD="19"
+set -o xtrace
+
 trap disclaimer ERR
 DRY_RUN=1
 
@@ -111,9 +119,6 @@ if [ "${DRY_RUN}" -ne 0 ]; then
     fi
     exit 2
 fi
-
-mkdir -p /var/log/crucible/
-exec 2>"/var/log/crucible/$(basename "$0").err"
 
 if [ -n "$root_disk" ]; then
     if [[ "$doomed_disks" =~ .*"/dev/${root_disk}".* ]]; then

--- a/docs/modules/ROOT/pages/nic-configuration.adoc
+++ b/docs/modules/ROOT/pages/nic-configuration.adoc
@@ -29,6 +29,7 @@ By obtaining the PCI Vendor and Device ID, we can provide customization for clas
 The information belongs to the first 4 bytes of the PCI header, and admin can obtain it using `lspci` or `ethtool`.
 
 If `crucible` is installed on the system, a helper script will be available in `/usr/bin`.
+
 [source,bash]
 ----
 /usr/bin/lsnics
@@ -70,10 +71,11 @@ Below is a table of commonly used devices for Fawkes system, this table will con
 |===
 |Vendor |Model |Device ID |Vendor ID
 
+|Broadcom Inc. and subsidiaries |BCM57414 NetXtreme-E |`16D7`|`14E4`
 |Intel Corporation |Ethernet Connection X722 |`37d2` |`8086`
 |Intel Corporation |82576 |`1526` |`8086`
-|Mellanox Technologies |ConnectX-4 |`1013` |*`15b3`*
-|Mellanox Technologies |ConnectX-5 |*`1017`* |`15b3`
+|Mellanox Technologies |ConnectX-4 |`1013` |`15b3`
+|Mellanox Technologies |ConnectX-5 |`1017` |`15b3`
 |Giga-Byte |Intel Corporation I350 |`1521` |`8086`
-|QLogic Corporation |FastLinQ QL41000 |`8070` |*`1077`*
+|QLogic Corporation |FastLinQ QL41000 |`8070` |`1077`
 |===


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

#### Issue Type

<!--- Delete un-needed bullets; choose one or more.  -->

- Bugfix Pull Request
- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
The primary change for this PR is a new function of the install and write-livecd script that updates the Crucible package with what was included in the Fawkes assets. This allows us to do a few things:
- We no longer need to always rebuild fawkes images if we have a new crucible version
- The crucible used in docs (the one from the tar) will consistently be available on the installed hypervisor

There is a gap at the moment for the PXE installed hypervisors, these are waiting on an additional change to auto-fetch the new Crucible (MTL-2300).

This also includes:
- Enhanced logging for easier debugging
- Broadcom PCIe support

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required).
- [ ] I have added unit tests for my code.
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.



-->

This does add some prototype code for the USB drive that may or may not work, but shouldn't interfere with anyone's runthrough.
