### PR TITLE
MTL-2367 Define management-vm

### DIFF
--- a/crucible/scripts/management-vm.sh
+++ b/crucible/scripts/management-vm.sh
@@ -214,8 +214,8 @@ xorriso -as genisoimage \
     "${MGMTCLOUD}/network-config"
 yq --xml-attribute-prefix='+@' -o xml -i -p xml eval '(.domain.devices.disk.[] | select(.source."+@file" == "*cloud-init.iso").source) |= {"+@file": "'"${MGMTCLOUD}/cloud-init.iso"'"}' "${BOOTSTRAP}/domain.xml"
 yq --xml-attribute-prefix='+@' -o xml -i -p xml eval '(.domain.devices.filesystem | select(.target."+@dir" == "assets").source) |= {"+@dir": "/vms/store0/assets"}' "${BOOTSTRAP}/domain.xml"
-virsh define "${BOOTSTRAP}/domain.xml"
-virsh autostart "${BOOTSTRAP}/domain.xml"
+virsh define "${BOOTSTRAP}/domain.xml" || echo "Domain already defined"
+virsh autostart "${BOOTSTRAP}/domain.xml" || echo "Autostart already enabled"
 virsh start "${BOOTSTRAP}/domain.xml"
 
 echo -en 'Management VM created ... observe startup with:\n\n'

--- a/crucible/scripts/management-vm.sh
+++ b/crucible/scripts/management-vm.sh
@@ -214,7 +214,9 @@ xorriso -as genisoimage \
     "${MGMTCLOUD}/network-config"
 yq --xml-attribute-prefix='+@' -o xml -i -p xml eval '(.domain.devices.disk.[] | select(.source."+@file" == "*cloud-init.iso").source) |= {"+@file": "'"${MGMTCLOUD}/cloud-init.iso"'"}' "${BOOTSTRAP}/domain.xml"
 yq --xml-attribute-prefix='+@' -o xml -i -p xml eval '(.domain.devices.filesystem | select(.target."+@dir" == "assets").source) |= {"+@dir": "/vms/store0/assets"}' "${BOOTSTRAP}/domain.xml"
-virsh create "${BOOTSTRAP}/domain.xml"
+virsh define "${BOOTSTRAP}/domain.xml"
+virsh autostart "${BOOTSTRAP}/domain.xml"
+virsh start "${BOOTSTRAP}/domain.xml"
 
 echo -en 'Management VM created ... observe startup with:\n\n'
 echo -en '\tvirsh console management-vm\n\n'


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2367

#### Issue Type

<!--- Delete un-needed bullets; choose one or more.  -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
The management-vm is created as a transient domain, this prevents it from persisting when shutdown.

In order to autostart the domain, we need to define it (make it persistent instead of transient).

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required).
- [ ] I have added unit tests for my code.
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
